### PR TITLE
Add contrib guide, demos list and main serve cmd

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,5 @@
 ## Contribution Guidelines
 
-### Contributor Agreement
-
-To contribute source code to this repository, please read our [Contributor Agreement](http://www.mulesoft.org/legal/contributor-agreement.html), and then execute it by running [this notebook](https://api-notebook.anypoint.mulesoft.com/notebooks/#380297ed0e474010ff43) and following the instructions.
-
 ## Setting-up this project locally
 
 ### Installation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+## Contribution Guidelines
+
+### Contributor Agreement
+
+To contribute source code to this repository, please read our [Contributor Agreement](http://www.mulesoft.org/legal/contributor-agreement.html), and then execute it by running [this notebook](https://api-notebook.anypoint.mulesoft.com/notebooks/#380297ed0e474010ff43) and following the instructions.
+
+## Setting-up this project locally
+
+### Installation
+```sh
+git clone git@github.com:aml-org/playground.git
+cd playground
+git checkout develop
+git clone git@github.com:aml-org/playground.git docs
+cd docs
+git checkout gh-pages
+cd ..
+npm install
+gulp bundleAll
+```
+
+### Running examples
+To run a demo, execute corresponding gulp `serve...` command. To get a list of all available `serve...` commands, please see [gulpfile.js](https://github.com/aml-org/playground/blob/master/gulpfile.js).
+
+### Creating pull requests
+Please create source code PRs to branch `develop` and html/css/etc to branch `gh-pages`.
+
+Before creating a PR, make sure to run `gulp bundleAll` so all the code is compiled/compressed. If you've followed [installation instructions](#installation), running `gulp bundleAll` should update both source code and compiled gh-pages code. This will allow you switch to `docs` directory and create a PR to `gh-pages` branch as well.

--- a/README.md
+++ b/README.md
@@ -2,16 +2,13 @@
 ![AML Playground Logo](docs/images/AML_white.svg)
 
 ## Demos
-* [Validation](https://a.ml/playground/validation.html)
-* [Visualization](https://a.ml/playground/visualization.html)
+* [Validation](https://github.com/aml-org/playground/tree/master/src/validation) ([Live Demo](https://a.ml/playground/validation.html))
+* [Visualization](https://github.com/aml-org/playground/tree/master/src/visualization) ([Live Demo](https://a.ml/playground/visualization.html))
 
 ## Running this project
-Validation demo:
 ```bash
-$ gulp serveValidation
+$ gulp serve
 ```
 
-Visualization demo:
-```bash
-$ gulp serveVisualization
-```
+## Contributing
+If you wish to contribute to this project, please review our [Contribution Guidelines](https://github.com/aml-org/playground/tree/master/CONTRIBUTING.md).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,3 +98,5 @@ gulp.task('bundleAll', gulp.series(
   'bundleValidation',
   'bundleVisualization'
 ))
+
+gulp.task('serve', gulp.series('serveValidation'))


### PR DESCRIPTION
As latest improvement comment say [here](https://github.com/aml-org/playground/issues/45):

> you can merge develop into master since we’re not yet using the playground in prod (and because we want 4. to link to folders in the master branch